### PR TITLE
Update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,14 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.2.3
+-   repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
     hooks:
     - id: flake8
+    additional_dependencies: [
+            'flake8-black',
+            'flake8-import-order',
+        ]
 -   repo: https://github.com/pycqa/isort
     rev: 5.11.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,4 +21,4 @@ repos:
     rev: 22.12.0
     hooks:
     - id: black
-      language_version: python3
+      language_version: python3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     rev: 5.0.4
     hooks:
     - id: flake8
-    additional_dependencies: [
+      additional_dependencies: [
             'flake8-black',
             'flake8-import-order',
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,9 @@ click
 Sphinx
 coverage
 # awscli
-flake8
+flake8==5.0.*
+flake8-black==0.3.*
+flake8-import-order==0.18.*
+pre-commit==2.21.*
+isort==5.11.*
 python-dotenv>=0.5.1


### PR DESCRIPTION
- Update pre-commit version to support only `3.8*`
- Changed repo of `flake8`
- Add a couple of dependencies for `flake8`
- Update requirements to include the versions of the `hooks`