### PR TITLE
Fix Cloud Registry not building Docker image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
    - name: 'gcr.io/cloud-builders/docker'
-     args: ['build', '-t', 'eu.gcr.io/dtumlops-project-group-55/trainer:latest', '.']
+     args: ['build', '-f', 'docker/trainer.ockerfile', '-t', 'eu.gcr.io/dtumlops-project-group-55/trainer:latest', '.']
    - name: 'gcr.io/cloud-builders/docker'
      args: ['push', 'gcr.io/dtumlops-project-group-55/trainer:latest']

--- a/docker/trainer.dockerfile
+++ b/docker/trainer.dockerfile
@@ -1,0 +1,11 @@
+FROM nvcr.io/nvidia/pytorch:22.07-py3
+
+RUN apt update
+
+WORKDIR /
+COPY ../requirements.txt requirements.txt
+COPY ../src/ src/
+COPY ../setup.py setup.py
+
+
+RUN pip install -r requirements.txt --no-cache-dir


### PR DESCRIPTION
Seems that the problem is that it could not locate the `Dockerfile`, since it is stored inside the `docker` directory instead of the `root` directory. Added `-f` parameter in the `cloudbuild.yaml` config file in order to fix this.

Hope it works :)))