### PR TITLE
Remove torch requirements since the image has pre-installed pytorch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,9 +24,9 @@ pytorch-lightning==1.8.6
 timm==0.6.12
 
 # pytorch requirements
-torch==1.13.1
-torchvision==0.14.1
-torchaudio==0.13.1
+#torch==1.13.1
+#torchvision==0.14.1
+#torchaudio==0.13.1
 
 
---find-links https://download.pytorch.org/whl/torch_stable.html
+#--find-links https://download.pytorch.org/whl/torch_stable.html


### PR DESCRIPTION
The currently used image has `pytorch` already installed. Removing these will shorten the build time