### PR TITLE
Re-order the stages of dockerfile

### DIFF
--- a/docker/trainer.dockerfile
+++ b/docker/trainer.dockerfile
@@ -2,12 +2,11 @@ FROM nvcr.io/nvidia/pytorch:22.07-py3
 
 RUN apt update
 
+RUN pip install --upgrade pip && \
+    pip install wheel setuptools h5py typing && \
+    pip install -r requirements.txt --no-cache-dir
+
 WORKDIR /
 COPY requirements.txt requirements.txt
 COPY src/ src/
 COPY setup.py setup.py
-
-
-RUN pip install --upgrade pip && \
-    pip install wheel setuptools h5py typing && \
-    pip install -r requirements.txt --no-cache-dir

--- a/docker/trainer.dockerfile
+++ b/docker/trainer.dockerfile
@@ -3,7 +3,6 @@ FROM nvcr.io/nvidia/pytorch:22.07-py3
 RUN apt update
 
 RUN pip install --upgrade pip && \
-    pip install wheel setuptools h5py typing && \
     pip install -r requirements.txt --no-cache-dir
 
 WORKDIR /


### PR DESCRIPTION
When a step of dockerfile need to be build again then all the following will have to be built again. Therefore, in order to take advantage of caching we put first those steps that will not be build again, such as `updating system`. Copying the code will always re-trigger the build